### PR TITLE
Prepare 0.11.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0-beta.1] - 2019-12-24
 ### Changed
 - `astarte`, `system` and all names starting with `system_` are now reserved realm names.
 - Add `database_retention_policy` and `database_retention_ttl` mapping attributes.

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.Core.Mixfile do
   def project do
     [
       app: :astarte_core,
-      version: "0.11.0-dev",
+      version: "0.11.0-beta.1",
       elixir: "~> 1.8",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Update CHANGELOG.md with 0.11.0-beta.1 release date and bump mix.exs
version.