### PR TITLE
Fix parametric automaton transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add support for aggregated server owned interfaces.
 
+### Fixed
+- Correctly handle parametric endpoints regardless of the ordering, so that overlapping endpoints are always refused. (See #2)
+
 ## [0.11.0-beta.2] - 2020-01-24
 ### Changed
 - Restrict the use of `*` as `interface_name` only to `incoming_data` data triggers.

--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -149,6 +149,14 @@ defmodule Astarte.Core.Mapping do
   end
 
   @doc """
+  Check if token is a placeholder.
+  """
+  @spec is_placeholder?(String.t()) :: boolean()
+  def is_placeholder?(token) when is_binary(token) do
+    String.match?(token, @placeholder_regex)
+  end
+
+  @doc """
   Deserializes a `%Mapping{}` from `db_result`.
   `db_result` can be a keyword list or a map.
 


### PR DESCRIPTION
When evaluating the transitions of a placeholder token, take all the possible transitions for that state