### PR TITLE
Get cyanide from hex.pm instead of GitHub

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Astarte.Core.Mixfile do
 
   defp deps do
     [
-      {:cyanide, github: "ispirata/cyanide"},
+      {:cyanide, "~> 1.0"},
       {:ecto, "~> 3.0"},
       {:exprotobuf, "~> 1.2"},
       {:jason, "~> 1.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "805abd97539caf89ec6d4732c91e62ba9da0cda51ac462380bbd28ee697a8c42"},
-  "cyanide": {:git, "https://github.com/ispirata/cyanide.git", "ad73635117de361147ab77300689815b32c385e3", []},
+  "cyanide": {:hex, :cyanide, "1.0.0", "9c2090e965f4254fea9ab2fa85e52a696e4e57547aec0babfa0a95fe1588ea76", [:mix], [], "hexpm", "74a8960fbde347c76f83dfedade938839b739770015f87dd724bba4a7cacdd96"},
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm", "52694ef56e60108e5012f8af9673874c66ed58ac1c4fae9b5b7ded31786663f5"},
   "dialyzex": {:git, "https://github.com/Comcast/dialyzex.git", "5e17345b61ba18bc5402a5d1b44a0bf04f2fb85c", []},
   "ecto": {:hex, :ecto, "3.1.6", "e890bf66c1d4d8e2b8e010f7cba092a08139b55437bc3382371f72a6ee40757e", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "e3056962ef9ecdfc48c195600d37e88bbc362b35da74e28ac7be1ab5347b59e1"},


### PR DESCRIPTION
Pull cyanide 1.0 from https://hex.pm/packages/cyanide