### PR TITLE
Add AMQP exchange to amqp_trigger_target.proto.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add `exchange` to `AMQPTriggerTarget` proto. This will allow to send events to any user defined
   AMQP exchange (see [#351](https://github.com/astarte-platform/astarte/issues/351)).
+- Add additional options to `AMQPTriggerTarget` such as `priority`, `expiration` and `persistent`.
 
 ## [0.11.0] - 2020-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `exchange` to `AMQPTriggerTarget` proto. This will allow to send events to any user defined
+  AMQP exchange (see [#351](https://github.com/astarte-platform/astarte/issues/351)).
 
 ## [0.11.0] - 2020-04-06
 

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/amqp_trigger_target.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/amqp_trigger_target.proto
@@ -26,4 +26,8 @@ message AMQPTriggerTarget {
     string routing_key = 4;
     map<string, string> static_headers = 5;
     string exchange = 6;
+
+    int32 message_expiration_ms = 7;
+    int32 message_priority = 8;
+    bool message_persistent = 9;
 }

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/amqp_trigger_target.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/amqp_trigger_target.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017-2020 Ispirata Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,4 +25,5 @@ message AMQPTriggerTarget {
 
     string routing_key = 4;
     map<string, string> static_headers = 5;
+    string exchange = 6;
 }


### PR DESCRIPTION
Make possible to use any AMQP exchange different than astarte_events.