### PR TITLE
Fix Ecto.Type warnings

### DIFF
--- a/lib/astarte_core/interface/aggregation.ex
+++ b/lib/astarte_core/interface/aggregation.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Interface.Aggregation do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @interface_aggregation_individual 1
   @interface_aggregation_object 2

--- a/lib/astarte_core/interface/ownership.ex
+++ b/lib/astarte_core/interface/ownership.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Interface.Ownership do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @interface_ownership_device 1
   @interface_ownership_server 2

--- a/lib/astarte_core/interface/type.ex
+++ b/lib/astarte_core/interface/type.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Interface.Type do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @interface_type_properties 1
   @interface_type_datastream 2

--- a/lib/astarte_core/mapping/database_retention_policy.ex
+++ b/lib/astarte_core/mapping/database_retention_policy.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Mapping.DatabaseRetentionPolicy do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @mapping_policy_no_ttl 1
   @mapping_policy_use_ttl 2

--- a/lib/astarte_core/mapping/reliability.ex
+++ b/lib/astarte_core/mapping/reliability.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Mapping.Reliability do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @mapping_reliability_unreliable 1
   @mapping_reliability_guaranteed 2

--- a/lib/astarte_core/mapping/retention.ex
+++ b/lib/astarte_core/mapping/retention.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Mapping.Retention do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @mapping_retention_discard 1
   @mapping_retention_volatile 2

--- a/lib/astarte_core/mapping/value_type.ex
+++ b/lib/astarte_core/mapping/value_type.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Mapping.ValueType do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @mapping_value_type_double 1
   @mapping_value_type_doublearray 2

--- a/lib/astarte_core/storage_type.ex
+++ b/lib/astarte_core/storage_type.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.StorageType do
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   @multi_interface_individual_properties_dbtable 1
   @multi_interface_individual_datastream_dbtable 2


### PR DESCRIPTION
Use `use Ecto.Type` instead of `@behaviour Ecto.Type` so we get the default
implementations of embed_as/1 and equal?/2

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>