### PR TITLE
Handle missing endpoint in mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.1] - Unreleased
+### Fixed
+- Return an error instead of crashing when the endpoint is not present within a mapping.
+
 ## [1.0.0-alpha.1] - 2020-06-18
 ### Added
 - Add `exchange` to `AMQPTriggerTarget` proto. This will allow to send events to any user defined

--- a/lib/astarte_core/interface.ex
+++ b/lib/astarte_core/interface.ex
@@ -195,7 +195,7 @@ defmodule Astarte.Core.Interface do
     changeset
   end
 
-  defp validate_mapping_uniqueness(changeset) do
+  defp validate_mapping_uniqueness(%Ecto.Changeset{valid?: true} = changeset) do
     mappings = get_field(changeset, :mappings, [])
 
     unique_count =
@@ -210,6 +210,10 @@ defmodule Astarte.Core.Interface do
     else
       changeset
     end
+  end
+
+  defp validate_mapping_uniqueness(%Ecto.Changeset{valid?: false} = changeset) do
+    changeset
   end
 
   defp validate_all_mappings_have_same_attributes(changeset) do


### PR DESCRIPTION
Return an error instead of crashing when the endpoint is not present within a mapping.
Fix #36 