### PR TITLE
Retrieve doc and description from db result

### DIFF
--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -196,7 +196,9 @@ defmodule Astarte.Core.Mapping do
       allow_unset: allow_unset,
       explicit_timestamp: explicit_timestamp,
       endpoint_id: endpoint_id,
-      interface_id: interface_id
+      interface_id: interface_id,
+      doc: Map.get(db_result, :doc),
+      description: Map.get(db_result, :description)
     }
   end
 

--- a/test/astarte_core/mapping_test.exs
+++ b/test/astarte_core/mapping_test.exs
@@ -75,7 +75,9 @@ defmodule Astarte.Core.MappingTest do
       "reliability" => "guaranteed",
       "expiry" => 60,
       "database_retention_policy" => "use_ttl",
-      "database_retention_ttl" => 60
+      "database_retention_ttl" => 60,
+      "doc" => "The doc.",
+      "description" => "The description."
     }
 
     assert %Ecto.Changeset{valid?: true} = changeset = Mapping.changeset(%Mapping{}, params, opts)
@@ -86,7 +88,9 @@ defmodule Astarte.Core.MappingTest do
              value_type: :integer,
              retention: :stored,
              reliability: :guaranteed,
-             expiry: 60
+             expiry: 60,
+             doc: "The doc.",
+             description: "The description."
            } = mapping
   end
 


### PR DESCRIPTION
When getting a mapping from the database, doc and description are retrieved.