### PR TITLE
Avoid failed check status on GitHub PR due to codecov bogus coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
Disable codecov status so it will not cause anymore codecov failed
status.