### PR TITLE
Extend mappings charset to support names prefixed with underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Extend interface mappings charset to support name prefixed with underscore
 
 ## [1.0.0-beta.2] - 2021-03-23
 ### Changed

--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -29,7 +29,7 @@ defmodule Astarte.Core.Mapping do
   alias Astarte.Core.Mapping.Reliability
   alias Astarte.Core.Mapping.Retention
 
-  @placeholder_regex ~r/%{[a-zA-Z]+[a-zA-Z0-9_]*}/
+  @placeholder_regex ~r/%{[a-zA-Z_]+[a-zA-Z0-9_]*}/
 
   @required_fields [
     :endpoint,
@@ -138,7 +138,7 @@ defmodule Astarte.Core.Mapping do
   end
 
   def mapping_regex do
-    ~r/^(\/(%{([a-zA-Z]+[a-zA-Z0-9_]*)}|[a-zA-Z]+[a-zA-Z0-9_]*)){1,64}$/
+    ~r/^(\/(%{([a-zA-Z_]+[a-zA-Z0-9_]*)}|[a-zA-Z_]+[a-zA-Z0-9_]*)){1,64}$/
   end
 
   @doc """

--- a/specs/mapping.json
+++ b/specs/mapping.json
@@ -6,7 +6,7 @@
     "properties": {
         "endpoint": {
             "type": "string",
-            "pattern": "^(/(%{([a-zA-Z][a-zA-Z0-9_]*)}|[a-zA-Z][a-zA-Z0-9_]*)){1,64}$",
+            "pattern": "^(/(%{([a-zA-Z_][a-zA-Z0-9_]*)}|[a-zA-Z_][a-zA-Z0-9_]*)){1,64}$",
             "minLength": 2,
             "maxLength": 256,
             "description": "The template of the path. This is a UNIX-like path (e.g. /my/path) and can be parametrized. Parameters are in the %{name} form, and can be used to create interfaces which represent dictionaries of mappings. When the interface aggregation is object, an object is composed by all the mappings for one specific parameter combination. /timestamp is a reserved path for timestamps, so every mapping on a datastream must not have any endpoint that ends with /timestamp."


### PR DESCRIPTION
Please consider to extend the charset for mappings allowing names prefixed with underscore