### PR TITLE
Fix validation of database_retention_ttl in Mapping's JSON schema

### DIFF
--- a/specs/mapping.json
+++ b/specs/mapping.json
@@ -34,6 +34,7 @@
         "expiry": {
             "type": "integer",
             "default": 0,
+            "minimum": 0,
             "description": "Useful when retention is stored. Defines after how many seconds a specific data entry should be kept before giving up and erasing it from the persistent cache. A value <= 0 means the persistent cache never expires, and is the default."
         },
         "database_retention_policy": {
@@ -44,7 +45,8 @@
         },
         "database_retention_ttl": {
             "type": "integer",
-            "default": 0,
+            "minimum": 60,
+            "maximum": 630719999,
             "description": "Useful when database_retention_policy is use_ttl. Defines how many seconds a specific data entry should be kept before erasing it from the database."
         },
         "allow_unset": {


### PR DESCRIPTION
This PR fixes the JSON Schema of the Mapping resource in order to have a correct validation on the `database_retention_ttl` field.
Indeed, the default value of 0 is stripped since it is invalid and a proper value range is specified.