### PR TITLE
Check database_retention_ttl and database_retention_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.2] - Unreleased
 ### Changed
 - Update dependencies and Elixir version to 1.11
+- If `database_retention_policy` is set to `:no_ttl`, `database_retention_ttl` must not be set. (See #51)
 
 ## [1.0.0-beta.1] - 2021-02-11
 ### Fixed

--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -99,6 +99,7 @@ defmodule Astarte.Core.Mapping do
     |> validate_not_set_unless(:explicit_timestamp, interface_type, [:datastream, nil])
     |> validate_length(:description, max: 1000)
     |> validate_length(:doc, max: 100_000)
+    |> validate_database_retention_policy_and_ttl()
     |> normalize_fields()
     |> put_change(:interface_id, interface_id)
     |> put_endpoint_id(interface_name, interface_major)
@@ -218,6 +219,20 @@ defmodule Astarte.Core.Mapping do
           []
         end
       end)
+    else
+      changeset
+    end
+  end
+
+  defp validate_database_retention_policy_and_ttl(changeset) do
+    # May return a more generic error if validate_not_set_unless/4 is used
+    if get_field(changeset, :database_retention_policy) == :no_ttl and
+         get_field(changeset, :database_retention_ttl) != nil do
+      add_error(
+        changeset,
+        :database_retention_policy,
+        "must be use_ttl if database_retention_ttl is set"
+      )
     else
       changeset
     end

--- a/test/astarte_core/mapping_test.exs
+++ b/test/astarte_core/mapping_test.exs
@@ -134,6 +134,54 @@ defmodule Astarte.Core.MappingTest do
            } = mapping
   end
 
+  test "mapping with no_ttl policy and valid database_retention_ttl set fails" do
+    opts = opts_fixture()
+
+    params = %{
+      "endpoint" => "/valid",
+      "type" => "string",
+      "reliability" => "guaranteed",
+      "database_retention_policy" => "no_ttl",
+      "database_retention_ttl" => 80
+    }
+
+    assert %Ecto.Changeset{valid?: false, errors: [database_retention_policy: _]} =
+             Mapping.changeset(%Mapping{}, params, opts)
+  end
+
+  test "mapping with no_ttl policy and invalid database_retention_ttl set fails" do
+    opts = opts_fixture()
+
+    params = %{
+      "endpoint" => "/valid",
+      "type" => "string",
+      "reliability" => "guaranteed",
+      "database_retention_policy" => "no_ttl",
+      "database_retention_ttl" => 0
+    }
+
+    assert %Ecto.Changeset{
+             valid?: false,
+             errors: [
+               {:database_retention_policy, _},
+               {:database_retention_ttl, _}
+             ]
+           } = Mapping.changeset(%Mapping{}, params, opts)
+  end
+
+  test "mapping with no_ttl policy and no database_retention_ttl succeeds" do
+    opts = opts_fixture()
+
+    params = %{
+      "endpoint" => "/valid",
+      "type" => "string",
+      "reliability" => "guaranteed",
+      "database_retention_policy" => "no_ttl"
+    }
+
+    assert %Ecto.Changeset{valid?: true} = Mapping.changeset(%Mapping{}, params, opts)
+  end
+
   test "mapping from legacy database result" do
     legacy_result = [
       endpoint: "/test",


### PR DESCRIPTION
If `database_retention_policy` is `no_ttl`, then `database_retention_ttl` must not be set.
See #51.