### PR TITLE
simple_events: correctly handle arrays and structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - Unreleased
+### Added
+- Handle array values when decoding simple events
+
+### Fixed
+- Don't treat structs as object aggregations when decoding simple events
+
 ## [1.0.0] - 2021-06-28
 
 ## [1.0.0-rc.0] - 2021-05-05

--- a/lib/astarte_core/triggers/simple_events/encoder.ex
+++ b/lib/astarte_core/triggers/simple_events/encoder.ex
@@ -277,8 +277,12 @@ defmodule Astarte.Core.Triggers.SimpleEvents.Encoder do
 
   def extract_bson_value(bson_value) do
     case Cyanide.decode!(bson_value) do
+      # Handle array types
+      %{"v" => array} when is_list(array) ->
+        Enum.map(array, &normalize_value/1)
+
       # With object aggregations we traverse all values to normalize them
-      %{"v" => object} when is_map(object) ->
+      %{"v" => object} when is_map(object) and not is_struct(object) ->
         for {k, v} <- object, into: %{} do
           {k, normalize_value(v)}
         end


### PR DESCRIPTION
- Map normalize_value/1 when decoding an array value
- Don't treat structs as maps (i.e. object aggregations), leave them as-is

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>