### PR TITLE
Standardize incoming introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Bump Elixir to 1.15.7.
 - Bump Erlang/OTP to 26.1.
+- IncomingIntrospectionEvent holds now a interface-name -> {major, minor} map
+  instead of the plain introspection string.
 
 ## [1.1.1] - 2023-10-03
 ### Fixed

--- a/lib/astarte_core/triggers/simple_events/incoming_introspection_event.pb.ex
+++ b/lib/astarte_core/triggers/simple_events/incoming_introspection_event.pb.ex
@@ -1,9 +1,31 @@
+defmodule Astarte.Core.Triggers.SimpleEvents.InterfaceVersion do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field :major, 1, type: :int32
+  field :minor, 2, type: :int32
+end
+
+defmodule Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent.IntrospectionMapEntry do
+  @moduledoc false
+
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field :key, 1, type: :string
+  field :value, 2, type: Astarte.Core.Triggers.SimpleEvents.InterfaceVersion
+end
+
 defmodule Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
-  def fully_qualified_name, do: "IncomingIntrospectionEvent"
+  field :introspection, 1, proto3_optional: true, type: :string, deprecated: true
 
-  field :introspection, 1, proto3_optional: true, type: :string
+  field :introspection_map, 2,
+    repeated: true,
+    type: Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent.IntrospectionMapEntry,
+    json_name: "introspectionMap",
+    map: true
 end

--- a/lib/astarte_core/triggers/simple_events/incoming_introspection_event.proto
+++ b/lib/astarte_core/triggers/simple_events/incoming_introspection_event.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017-2024 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,12 @@
 
 syntax = "proto3";
 
+message InterfaceVersion {
+  int32 major = 1;
+  int32 minor = 2;
+}
+
 message IncomingIntrospectionEvent {
-  optional string introspection = 1;
+  optional string introspection = 1 [deprecated = true];
+  map<string, InterfaceVersion> introspection_map = 2;
 }

--- a/test/astarte_core/triggers/simple_events_test.exs
+++ b/test/astarte_core/triggers/simple_events_test.exs
@@ -412,4 +412,31 @@ defmodule Astarte.Core.SimpleEventsTest do
       assert ValueStoredEvent.decode(serialized_event) == event
     end
   end
+
+  describe "IncomingIntrospectionEvent" do
+    alias Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent
+
+    test "is correctly serialized when payload is a string" do
+      introspection_string = "com.an.Interface:1:0;com.another.Interface:0:1"
+
+      event = %IncomingIntrospectionEvent{introspection: introspection_string}
+
+      assert ^event =
+               IncomingIntrospectionEvent.encode(event) |> IncomingIntrospectionEvent.decode()
+    end
+
+    test "is correctly serialized when payload is a map" do
+      alias Astarte.Core.Triggers.SimpleEvents.InterfaceVersion
+
+      introspection_map = %{
+        "com.an.Interface" => %InterfaceVersion{major: 1, minor: 0},
+        "com.another.Interface" => %InterfaceVersion{major: 0, minor: 1}
+      }
+
+      event = %IncomingIntrospectionEvent{introspection_map: introspection_map}
+
+      assert ^event =
+               IncomingIntrospectionEvent.encode(event) |> IncomingIntrospectionEvent.decode()
+    end
+  end
 end


### PR DESCRIPTION
The payload should be an interface -> (major, minor) map, and not just a string.
Replace the old `introspection` field (a string) with the `instrospection_map` field.
Keep the old plain introspection string as deprecated.