### PR TITLE
Make `.proto` files conform to protobuf specification 

### DIFF
--- a/lib/astarte_core/proto/astarte_reference.proto
+++ b/lib/astarte_core/proto/astarte_reference.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message AstarteReference {
     int32 object_type = 1;
     bytes object_uuid = 2;

--- a/lib/astarte_core/triggers/policy_protobuf/error_keyword.proto
+++ b/lib/astarte_core/triggers/policy_protobuf/error_keyword.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message ErrorKeyword {
 
     enum KeywordType {

--- a/lib/astarte_core/triggers/policy_protobuf/error_range.proto
+++ b/lib/astarte_core/triggers/policy_protobuf/error_range.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message ErrorRange {
     repeated int32 error_codes = 1;
 }

--- a/lib/astarte_core/triggers/policy_protobuf/handler.proto
+++ b/lib/astarte_core/triggers/policy_protobuf/handler.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message Handler {
     
     enum StrategyType {

--- a/lib/astarte_core/triggers/policy_protobuf/policy.proto
+++ b/lib/astarte_core/triggers/policy_protobuf/policy.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message Policy {
     string name = 1;
     int32 maximum_capacity = 2;

--- a/lib/astarte_core/triggers/simple_events/device_connected_event.proto
+++ b/lib/astarte_core/triggers/simple_events/device_connected_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message DeviceConnectedEvent {
   string device_ip_address = 1;
 }

--- a/lib/astarte_core/triggers/simple_events/device_disconnected_event.proto
+++ b/lib/astarte_core/triggers/simple_events/device_disconnected_event.proto
@@ -16,5 +16,7 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message DeviceDisconnectedEvent {
 }

--- a/lib/astarte_core/triggers/simple_events/incoming_data_event.proto
+++ b/lib/astarte_core/triggers/simple_events/incoming_data_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message IncomingDataEvent {
   string interface = 1;
   string path = 2;

--- a/lib/astarte_core/triggers/simple_events/incoming_introspection_event.proto
+++ b/lib/astarte_core/triggers/simple_events/incoming_introspection_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message IncomingIntrospectionEvent {
   string introspection = 1;
 }

--- a/lib/astarte_core/triggers/simple_events/interface_added_event.proto
+++ b/lib/astarte_core/triggers/simple_events/interface_added_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message InterfaceAddedEvent {
   string interface = 1;
   int32 major_version = 2;

--- a/lib/astarte_core/triggers/simple_events/interface_minor_updated_event.proto
+++ b/lib/astarte_core/triggers/simple_events/interface_minor_updated_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message InterfaceMinorUpdatedEvent {
   string interface = 1;
   int32 major_version = 2;

--- a/lib/astarte_core/triggers/simple_events/interface_removed_event.proto
+++ b/lib/astarte_core/triggers/simple_events/interface_removed_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message InterfaceRemovedEvent {
   string interface = 1;
   int32 major_version = 2;

--- a/lib/astarte_core/triggers/simple_events/path_created_event.proto
+++ b/lib/astarte_core/triggers/simple_events/path_created_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message PathCreatedEvent {
   string interface = 1;
   string path = 2;

--- a/lib/astarte_core/triggers/simple_events/path_removed_event.proto
+++ b/lib/astarte_core/triggers/simple_events/path_removed_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message PathRemovedEvent {
   string interface = 1;
   string path = 2;

--- a/lib/astarte_core/triggers/simple_events/simple_event.proto
+++ b/lib/astarte_core/triggers/simple_events/simple_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message SimpleEvent {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/simple_events/value_change_applied_event.proto
+++ b/lib/astarte_core/triggers/simple_events/value_change_applied_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message ValueChangeAppliedEvent {
   string interface = 1;
   string path = 2;

--- a/lib/astarte_core/triggers/simple_events/value_change_event.proto
+++ b/lib/astarte_core/triggers/simple_events/value_change_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message ValueChangeEvent {
   string interface = 1;
   string path = 2;

--- a/lib/astarte_core/triggers/simple_events/value_stored_event.proto
+++ b/lib/astarte_core/triggers/simple_events/value_stored_event.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message ValueStoredEvent {
   string interface = 1;
   string path = 2;

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/amqp_trigger_target.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/amqp_trigger_target.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message AMQPTriggerTarget {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/data_trigger.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/data_trigger.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message DataTrigger {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/device_trigger.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/device_trigger.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message DeviceTrigger {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/simple_trigger_container.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/simple_trigger_container.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message SimpleTriggerContainer {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/tagged_simple_trigger.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/tagged_simple_trigger.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message TaggedSimpleTrigger {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/simple_triggers_protobuf/trigger_target_container.proto
+++ b/lib/astarte_core/triggers/simple_triggers_protobuf/trigger_target_container.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message TriggerTargetContainer {
     int32 version = 1 [default = 1];
 

--- a/lib/astarte_core/triggers/trigger.proto
+++ b/lib/astarte_core/triggers/trigger.proto
@@ -16,6 +16,8 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 message Trigger {
     int32 version = 1 [default = 1];
 


### PR DESCRIPTION
.proto files do not specify which version of the Protobuf language is used. This, among other things, makes them invalid.
Add the right version (`proto3`).