### PR TITLE
Mappings: ensure a TTL is set when using TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - Unreleased
+### Fixed
+- Do not allow mappings where `database_retention_policy` is
+  `use_ttl` but no ttl is set. Fix #84.
+
 ## [1.0.4] - 2022-09-26
 
 ## [1.0.3] - 2022-07-04

--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -225,16 +225,24 @@ defmodule Astarte.Core.Mapping do
   end
 
   defp validate_database_retention_policy_and_ttl(changeset) do
-    # May return a more generic error if validate_not_set_unless/4 is used
-    if get_field(changeset, :database_retention_policy) == :no_ttl and
-         get_field(changeset, :database_retention_ttl) != nil do
-      add_error(
-        changeset,
-        :database_retention_policy,
-        "must be use_ttl if database_retention_ttl is set"
-      )
-    else
-      changeset
+    case {get_field(changeset, :database_retention_policy),
+          get_field(changeset, :database_retention_ttl)} do
+      {:no_ttl, any} when not is_nil(any) ->
+        add_error(
+          changeset,
+          :database_retention_policy,
+          "must be use_ttl if database_retention_ttl is set"
+        )
+
+      {:use_ttl, nil} ->
+        add_error(
+          changeset,
+          :database_retention_ttl,
+          "must be set if database_retention_policy is use_ttl"
+        )
+
+      _ ->
+        changeset
     end
   end
 

--- a/test/astarte_core/mapping_test.exs
+++ b/test/astarte_core/mapping_test.exs
@@ -182,6 +182,24 @@ defmodule Astarte.Core.MappingTest do
     assert %Ecto.Changeset{valid?: true} = Mapping.changeset(%Mapping{}, params, opts)
   end
 
+  test "mapping with use_ttl policy and no database_retention_ttl fails" do
+    opts = opts_fixture()
+
+    params = %{
+      "endpoint" => "/invalid",
+      "type" => "string",
+      "reliability" => "guaranteed",
+      "database_retention_policy" => "use_ttl"
+    }
+
+    assert %Ecto.Changeset{
+             valid?: false,
+             errors: [
+               {:database_retention_ttl, _}
+             ]
+           } = Mapping.changeset(%Mapping{}, params, opts)
+  end
+
   test "mapping from legacy database result" do
     legacy_result = [
       endpoint: "/test",


### PR DESCRIPTION
Do not allow mappings where `database_retention_policy` is `use_ttl` but no ttl is set.
Fix (and answer to) #84.