### PR TITLE
Correctly encode binaryblobarrays in JSON payload of Astarte events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - Unreleased
+### Fixed
+- Correctly encode binaryblobarrays in JSON payload of Astarte events.
+
 ## [1.1.0] - 2023-06-20
 ### Fixed
 - Forward ported changes from 1.0.5 (Do not allow mappings where `database_retention_policy`...)

--- a/lib/astarte_core/triggers/simple_events/encoder.ex
+++ b/lib/astarte_core/triggers/simple_events/encoder.ex
@@ -300,6 +300,11 @@ defmodule Astarte.Core.Triggers.SimpleEvents.Encoder do
     Base.encode64(value)
   end
 
+  # Special case: make sure binary bson type is base64 encoded inside arrays in objects, too
+  defp normalize_value(binary_array) when is_list(binary_array) do
+    Enum.map(binary_array, &normalize_value/1)
+  end
+
   defp normalize_value(value) do
     value
   end

--- a/test/astarte_core/triggers/simple_events_encoder_test.exs
+++ b/test/astarte_core/triggers/simple_events_encoder_test.exs
@@ -213,6 +213,34 @@ defmodule Astarte.Core.SimpleEventsEncoderTest do
              }
     end
 
+    test "works for IncomingDataEvent with binaryblobarray bson_value in an object" do
+      alias Astarte.Core.Triggers.SimpleEvents.IncomingDataEvent
+
+      interface = "com.example.Interface"
+      path = "/another"
+      values = [<<1, 2, 3, 230>>, <<4, 5, 6, 230>>]
+      object_values = %{"/path" => Enum.map(values, &{0, &1})}
+      bson_value = Cyanide.encode!(%{v: object_values})
+      expected_value = %{"/path" => Enum.map(values, &Base.encode64/1)}
+
+      event = %IncomingDataEvent{
+        interface: interface,
+        path: path,
+        bson_value: bson_value
+      }
+
+      roundtrip =
+        Jason.encode!(event)
+        |> Jason.decode!()
+
+      assert roundtrip == %{
+               "type" => "incoming_data",
+               "interface" => interface,
+               "path" => path,
+               "value" => expected_value
+             }
+    end
+
     test "works for IncomingIntrospectionEvent" do
       alias Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent
 


### PR DESCRIPTION
Encode binaryblobarray in object-aggregated values in Astarte events as JSON arrays of base64-encoded values rather than a list of `%Cyanide.Binary{}` structs.
