### PR TITLE
Add translation function from realm to keyspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Function for translating realm to keyspace, to support multiple Astarte 
+  instances sharing the same database
+
 ### Changed
 - Bump Elixir to 1.15.7.
 - Bump Erlang/OTP to 26.1.

--- a/lib/astarte_core/cql_utils.ex
+++ b/lib/astarte_core/cql_utils.ex
@@ -167,4 +167,19 @@ defmodule Astarte.Core.CQLUtils do
 
     eid
   end
+
+  @spec realm_name_to_keyspace_name(nonempty_binary(), binary()) :: nonempty_binary()
+  def realm_name_to_keyspace_name(realm_name, astarte_instance_id \\ "")
+      when is_binary(realm_name) do
+    instance_and_realm = astarte_instance_id <> realm_name
+
+    case String.length(instance_and_realm) do
+      len when len >= 48 -> Base.url_encode64(instance_and_realm, padding: false)
+      _ -> instance_and_realm
+    end
+    |> String.replace("-", "")
+    |> String.replace("_", "")
+    |> String.slice(0..47)
+    |> String.downcase()
+  end
 end

--- a/test/astarte_core/cql_utils_test.exs
+++ b/test/astarte_core/cql_utils_test.exs
@@ -1,6 +1,7 @@
 defmodule CQLUtilsTest do
   use ExUnit.Case
   alias Astarte.Core.CQLUtils
+  alias Astarte.Core.Realm
 
   test "interface name to table name" do
     assert CQLUtils.interface_name_to_table_name("com.ispirata.Hemera.DeviceLog", 1) ==
@@ -147,5 +148,30 @@ defmodule CQLUtilsTest do
 
     assert Astarte.Core.CQLUtils.endpoint_id("com.foo", 2, "/a/%{something}/foo") !=
              Astarte.Core.CQLUtils.endpoint_id("com.foo", 2, "/a/%{something}/bar")
+  end
+
+  describe "Realm name to keyspace name translation" do
+    test "works with a short realm name that does not get encoded" do
+      assert CQLUtils.realm_name_to_keyspace_name("example", "atestinstance") ==
+               "atestinstanceexample"
+
+      assert Realm.valid_name?(CQLUtils.realm_name_to_keyspace_name("example", "atestinstance")) ==
+               true
+    end
+
+    test "works with a long realm name that does get encoded" do
+      assert CQLUtils.realm_name_to_keyspace_name(
+               "averyveryverylongrealmnamejustforthistest",
+               "atestinstance"
+             ) ==
+               "yxrlc3rpbnn0yw5jzwf2zxj5dmvyexzlcnlsb25ncmvhbg1u"
+
+      assert Realm.valid_name?(
+               CQLUtils.realm_name_to_keyspace_name(
+                 "averyveryverylongrealmnamejustforthistest",
+                 "atestinstance"
+               )
+             ) == true
+    end
   end
 end


### PR DESCRIPTION
Added a function to support new database keyspaces separation.
The function translate from a realm name to a keyspace name, derived from realm + astarte_instance_id (optional parameter).

This edit has became necessary before an extensive rewriting of the main astarte repo, in order to add the database keyspaces separation feature.

New tests have been written to cover main and side cases.

After internal discussion, this feature does not use persistent_term anymore


