### PR TITLE
feat: bangs of standard ecto.type functions

### DIFF
--- a/lib/astarte_core/interface/aggregation.ex
+++ b/lib/astarte_core/interface/aggregation.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,22 @@ defmodule Astarte.Core.Interface.Aggregation do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, aggregation} ->
+        aggregation
+
+      :error ->
+        raise ArgumentError,
+          message: "#{inspect(value)} is not a valid aggregation representation"
+    end
+  end
 
   @impl true
   def dump(aggregation) when is_atom(aggregation) do
@@ -59,7 +74,7 @@ defmodule Astarte.Core.Interface.Aggregation do
     end
   end
 
-  def to_int(aggregation) when is_atom(aggregation) do
+  def dump!(aggregation) when is_atom(aggregation) do
     case dump(aggregation) do
       {:ok, aggregation_int} -> aggregation_int
       :error -> raise ArgumentError, message: "#{inspect(aggregation)} is not a valid aggregation"
@@ -75,14 +90,11 @@ defmodule Astarte.Core.Interface.Aggregation do
     end
   end
 
-  def from_int(aggregation_int) when is_integer(aggregation_int) do
-    case load(aggregation_int) do
-      {:ok, aggregation} ->
-        aggregation
+  def to_int(aggregation) when is_atom(aggregation) do
+    dump!(aggregation)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{aggregation_int} is not a valid aggregation int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end

--- a/lib/astarte_core/interface/ownership.ex
+++ b/lib/astarte_core/interface/ownership.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,7 +60,21 @@ defmodule Astarte.Core.Interface.Ownership do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, ownership} ->
+        ownership
+
+      :error ->
+        raise ArgumentError, message: "#{inspect(value)} is not a valid ownership representation"
+    end
+  end
 
   @impl true
   def dump(ownership) when is_atom(ownership) do
@@ -71,7 +85,7 @@ defmodule Astarte.Core.Interface.Ownership do
     end
   end
 
-  def to_int(ownership) when is_atom(ownership) do
+  def dump!(ownership) when is_atom(ownership) do
     case dump(ownership) do
       {:ok, ownership_int} -> ownership_int
       :error -> raise ArgumentError, message: "#{inspect(ownership)} is not a valid ownership"
@@ -87,14 +101,11 @@ defmodule Astarte.Core.Interface.Ownership do
     end
   end
 
-  def from_int(ownership_int) when is_integer(ownership_int) do
-    case load(ownership_int) do
-      {:ok, ownership} ->
-        ownership
+  def to_int(ownership) when is_atom(ownership) do
+    dump!(ownership)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{ownership_int} is not a valid ownership int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end

--- a/lib/astarte_core/interface/type.ex
+++ b/lib/astarte_core/interface/type.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,22 @@ defmodule Astarte.Core.Interface.Type do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, type} ->
+        type
+
+      :error ->
+        raise ArgumentError,
+          message: "#{inspect(value)} is not a valid interface type representation"
+    end
+  end
 
   @impl true
   def dump(type) when is_atom(type) do
@@ -59,7 +74,7 @@ defmodule Astarte.Core.Interface.Type do
     end
   end
 
-  def to_int(type) when is_atom(type) do
+  def dump!(type) when is_atom(type) do
     case dump(type) do
       {:ok, type_int} -> type_int
       :error -> raise ArgumentError, message: "#{inspect(type)} is not a valid interface type"
@@ -75,14 +90,11 @@ defmodule Astarte.Core.Interface.Type do
     end
   end
 
-  def from_int(type_int) when is_integer(type_int) do
-    case load(type_int) do
-      {:ok, type} ->
-        type
+  def to_int(interface) when is_atom(interface) do
+    dump!(interface)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{type_int} is not a valid interface type int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end

--- a/lib/astarte_core/interface_descriptor.ex
+++ b/lib/astarte_core/interface_descriptor.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,11 +66,11 @@ defmodule Astarte.Core.InterfaceDescriptor do
         name: name,
         major_version: major_version,
         minor_version: minor_version,
-        type: Type.from_int(type),
-        ownership: Ownership.from_int(ownership),
-        aggregation: Aggregation.from_int(aggregation),
+        type: Type.cast!(type),
+        ownership: Ownership.cast!(ownership),
+        aggregation: Aggregation.cast!(aggregation),
         storage: storage,
-        storage_type: StorageType.from_int(storage_type),
+        storage_type: StorageType.cast!(storage_type),
         automaton:
           {:erlang.binary_to_term(automaton_transitions),
            :erlang.binary_to_term(automaton_accepting_states)},

--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -185,29 +185,29 @@ defmodule Astarte.Core.Mapping do
       interface_id: interface_id
     } = db_result
 
+    database_retention_policy =
+      database_retention_policy
+      |> Kernel.||(:no_ttl)
+      |> DatabaseRetentionPolicy.cast!()
+
+    doc = Map.get(db_result, :doc)
+    description = Map.get(db_result, :description)
+
     %Mapping{
       endpoint: endpoint,
-      value_type: ValueType.from_int(value_type),
-      reliability: Reliability.from_int(reliability),
-      retention: Retention.from_int(retention),
+      value_type: ValueType.cast!(value_type),
+      reliability: Reliability.cast!(reliability),
+      retention: Retention.cast!(retention),
       expiry: expiry,
-      database_retention_policy:
-        database_retention_policy_from_maybe_int(database_retention_policy),
+      database_retention_policy: database_retention_policy,
       database_retention_ttl: database_retention_ttl,
       allow_unset: allow_unset,
       explicit_timestamp: explicit_timestamp,
       endpoint_id: endpoint_id,
       interface_id: interface_id,
-      doc: Map.get(db_result, :doc),
-      description: Map.get(db_result, :description)
+      doc: doc,
+      description: description
     }
-  end
-
-  defp database_retention_policy_from_maybe_int(database_retention_policy) do
-    case database_retention_policy do
-      nil -> :no_ttl
-      _any_int -> DatabaseRetentionPolicy.from_int(database_retention_policy)
-    end
   end
 
   defp validate_not_set_unless(changeset, field, param, values) do

--- a/lib/astarte_core/mapping/database_retention_policy.ex
+++ b/lib/astarte_core/mapping/database_retention_policy.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,22 @@ defmodule Astarte.Core.Mapping.DatabaseRetentionPolicy do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, policy} ->
+        policy
+
+      :error ->
+        raise ArgumentError,
+          message: "#{inspect(value)} is not a valid database retention policy representation"
+    end
+  end
 
   @impl true
   def dump(policy) when is_atom(policy) do
@@ -59,10 +74,10 @@ defmodule Astarte.Core.Mapping.DatabaseRetentionPolicy do
     end
   end
 
-  def to_int(policy) when is_atom(policy) do
+  def dump!(policy) when is_atom(policy) do
     case dump(policy) do
-      {:ok, int} ->
-        int
+      {:ok, policy_int} ->
+        policy_int
 
       :error ->
         raise ArgumentError,
@@ -79,14 +94,11 @@ defmodule Astarte.Core.Mapping.DatabaseRetentionPolicy do
     end
   end
 
-  def from_int(policy_int) when is_integer(policy_int) do
-    case load(policy_int) do
-      {:ok, policy} ->
-        policy
+  def to_int(database_retention_policy) when is_atom(database_retention_policy) do
+    dump!(database_retention_policy)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{policy_int} is not a valid database retention policy int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end

--- a/lib/astarte_core/mapping/reliability.ex
+++ b/lib/astarte_core/mapping/reliability.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,22 @@ defmodule Astarte.Core.Mapping.Reliability do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(reliability) do
+    case cast(reliability) do
+      {:ok, reliability} ->
+        reliability
+
+      :error ->
+        raise ArgumentError,
+          message: "#{inspect(reliability)} is not a valid reliability representation"
+    end
+  end
 
   @impl true
   def dump(reliability) when is_atom(reliability) do
@@ -63,9 +78,9 @@ defmodule Astarte.Core.Mapping.Reliability do
     end
   end
 
-  def to_int(reliability) when is_atom(reliability) do
+  def dump!(reliability) when is_atom(reliability) do
     case dump(reliability) do
-      {:ok, int} -> int
+      {:ok, reliability_int} -> reliability_int
       :error -> raise ArgumentError, message: "#{inspect(reliability)} is not a valid reliability"
     end
   end
@@ -80,14 +95,11 @@ defmodule Astarte.Core.Mapping.Reliability do
     end
   end
 
-  def from_int(reliability_int) when is_integer(reliability_int) do
-    case load(reliability_int) do
-      {:ok, reliability} ->
-        reliability
+  def to_int(reliability) when is_atom(reliability) do
+    dump!(reliability)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{reliability_int} is not a valid reliability int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end

--- a/lib/astarte_core/mapping/retention.ex
+++ b/lib/astarte_core/mapping/retention.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,21 @@ defmodule Astarte.Core.Mapping.Retention do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, retention} ->
+        retention
+
+      :error ->
+        raise ArgumentError, message: "#{inspect(value)} is not a valid retention representation"
+    end
+  end
 
   @impl true
   def dump(retention) when is_atom(retention) do
@@ -63,9 +77,9 @@ defmodule Astarte.Core.Mapping.Retention do
     end
   end
 
-  def to_int(retention) when is_atom(retention) do
+  def dump!(retention) when is_atom(retention) do
     case dump(retention) do
-      {:ok, int} -> int
+      {:ok, retention_int} -> retention_int
       :error -> raise ArgumentError, message: "#{inspect(retention)} is not a valid retention"
     end
   end
@@ -80,14 +94,11 @@ defmodule Astarte.Core.Mapping.Retention do
     end
   end
 
-  def from_int(retention_int) when is_integer(retention_int) do
-    case load(retention_int) do
-      {:ok, retention} ->
-        retention
+  def to_int(retention) when is_atom(retention) do
+    dump!(retention)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{retention_int} is not a valid retention int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end

--- a/lib/astarte_core/mapping/value_type.ex
+++ b/lib/astarte_core/mapping/value_type.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -90,7 +90,21 @@ defmodule Astarte.Core.Mapping.ValueType do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, value_type} ->
+        value_type
+
+      :error ->
+        raise ArgumentError, message: "#{inspect(value)} is not a valid value type representation"
+    end
+  end
 
   @impl true
   def dump(value_type) when is_atom(value_type) do
@@ -113,9 +127,9 @@ defmodule Astarte.Core.Mapping.ValueType do
     end
   end
 
-  def to_int(value_type) when is_atom(value_type) do
+  def dump!(value_type) when is_atom(value_type) do
     case dump(value_type) do
-      {:ok, int} -> int
+      {:ok, value_type_int} -> value_type_int
       :error -> raise ArgumentError, message: "#{inspect(value_type)} is not a valid value type"
     end
   end
@@ -141,15 +155,12 @@ defmodule Astarte.Core.Mapping.ValueType do
     end
   end
 
-  def from_int(value_type_int) when is_integer(value_type_int) do
-    case load(value_type_int) do
-      {:ok, value_type} ->
-        value_type
+  def to_int(value_type) when is_atom(value_type) do
+    dump!(value_type)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{value_type_int} is not a valid value type int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 
   def validate_value(expected_type, value) do

--- a/lib/astarte_core/storage_type.ex
+++ b/lib/astarte_core/storage_type.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2018 Ispirata Srl
+# Copyright 2017-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,22 @@ defmodule Astarte.Core.StorageType do
     end
   end
 
+  def cast(int) when is_integer(int) do
+    load(int)
+  end
+
   def cast(_), do: :error
+
+  def cast!(value) do
+    case cast(value) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        raise ArgumentError,
+          message: "#{inspect(value)} is not a valid storage type representation"
+    end
+  end
 
   @impl true
   def dump(storage_type) when is_atom(storage_type) do
@@ -71,10 +86,7 @@ defmodule Astarte.Core.StorageType do
     end
   end
 
-  @doc """
-  returns storage_type associated int value.
-  """
-  def to_int(storage_type) when is_atom(storage_type) do
+  def dump!(storage_type) when is_atom(storage_type) do
     case dump(storage_type) do
       {:ok, storage_type_int} ->
         storage_type_int
@@ -107,17 +119,11 @@ defmodule Astarte.Core.StorageType do
     end
   end
 
-  @doc """
-  returns storage_type atom from a valid storage type int value.
-  """
-  def from_int(storage_type_int) when is_integer(storage_type_int) do
-    case load(storage_type_int) do
-      {:ok, storage_type} ->
-        storage_type
+  def to_int(storage_type) when is_atom(storage_type) do
+    dump!(storage_type)
+  end
 
-      :error ->
-        raise ArgumentError,
-          message: "#{storage_type_int} is not a valid storage type int representation"
-    end
+  def from_int(int) when is_integer(int) do
+    cast!(int)
   end
 end


### PR DESCRIPTION
implement to_int and from_int functions as ecto cast! and dump!

by using cast! in InterfaceDescriptor.from_db_result and Mapping.from_db_result!, they can now also accept atom values

this is useful when calling the function with an exandra object