### PR TITLE
feat(capabilities): device capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Function for translating realm to keyspace, to support multiple Astarte 
   instances sharing the same database
+- Added device capabilities
+- Added device capability `purge_property_compression_format`
 
 ### Changed
 - Bump Elixir to 1.15.7.

--- a/lib/astarte_core/device/capabilities.ex
+++ b/lib/astarte_core/device/capabilities.ex
@@ -1,0 +1,43 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.Core.Device.Capabilities do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Astarte.Core.Device.Capabilities
+
+  @required_fields []
+
+  @permitted_fields [:purge_properties_compression_format] ++ @required_fields
+
+  @primary_key false
+  embedded_schema do
+    field :purge_properties_compression_format, Ecto.Enum,
+      values: [zlib: 0, plaintext: 1],
+      default: :zlib
+  end
+
+  def changeset(%Capabilities{} = capabilities, params \\ %{}) do
+    capabilities
+    |> cast(params, @permitted_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/test/astarte_core/device/capabilities_test.exs
+++ b/test/astarte_core/device/capabilities_test.exs
@@ -1,0 +1,63 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.Core.Device.CapabilitiesTest do
+  use ExUnit.Case
+
+  alias Astarte.Core.Device.Capabilities
+
+  test "capabilities with :purge_properties_compression_format :zlib" do
+    params = %{
+      "purge_properties_compression_format" => "zlib"
+    }
+
+    changeset = Capabilities.changeset(%Capabilities{}, params)
+
+    assert %Ecto.Changeset{valid?: true} = changeset
+
+    {:ok, capabilities} = Ecto.Changeset.apply_action(changeset, :insert)
+
+    assert %Capabilities{purge_properties_compression_format: :zlib} = capabilities
+  end
+
+  test "capabilities with :purge_properties_compression_format :plaintext" do
+    params = %{
+      "purge_properties_compression_format" => "plaintext"
+    }
+
+    changeset = Capabilities.changeset(%Capabilities{}, params)
+
+    assert %Ecto.Changeset{valid?: true} = changeset
+
+    {:ok, capabilities} = Ecto.Changeset.apply_action(changeset, :insert)
+
+    assert %Capabilities{purge_properties_compression_format: :plaintext} = capabilities
+  end
+
+  test "capabilities with invalid :purge_properties_compression_format fails" do
+    params = %{
+      purge_properties_compression_format: :invalid
+    }
+
+    changeset = Capabilities.changeset(%Capabilities{}, params)
+
+    assert %Ecto.Changeset{valid?: false} = changeset
+  end
+end


### PR DESCRIPTION
- Adds device capabilities ecto schema
- Adds capability `:purge_properties_format` capability with `:zlib` and `:plaintext` possible values