### PR TITLE
chore: define type `t` for all custom types

### DIFF
--- a/lib/astarte_core/interface.ex
+++ b/lib/astarte_core/interface.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Interface do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
   alias Astarte.Core.CQLUtils
@@ -45,7 +45,7 @@ defmodule Astarte.Core.Interface do
   ]
 
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :interface_id, :binary
     field :name
     field :major_version, :integer

--- a/lib/astarte_core/interface/aggregation.ex
+++ b/lib/astarte_core/interface/aggregation.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.Core.Interface.Aggregation do
   use Ecto.Type
 
+  @type t :: :individual | :object
+
   @interface_aggregation_individual 1
   @interface_aggregation_object 2
   @valid_atoms [

--- a/lib/astarte_core/interface/ownership.ex
+++ b/lib/astarte_core/interface/ownership.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.Core.Interface.Ownership do
   use Ecto.Type
 
+  @type t :: :device | :server
+
   @interface_ownership_device 1
   @interface_ownership_server 2
   @valid_atoms [

--- a/lib/astarte_core/interface/type.ex
+++ b/lib/astarte_core/interface/type.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.Core.Interface.Type do
   use Ecto.Type
 
+  @type t :: :properties | :datastream
+
   @interface_type_properties 1
   @interface_type_datastream 2
   @valid_atoms [

--- a/lib/astarte_core/interface_descriptor.ex
+++ b/lib/astarte_core/interface_descriptor.ex
@@ -17,6 +17,8 @@
 #
 
 defmodule Astarte.Core.InterfaceDescriptor do
+  use TypedStruct
+
   alias Astarte.Core.Interface
   alias Astarte.Core.Interface.Aggregation
   alias Astarte.Core.Interface.Ownership
@@ -24,16 +26,18 @@ defmodule Astarte.Core.InterfaceDescriptor do
   alias Astarte.Core.InterfaceDescriptor
   alias Astarte.Core.StorageType
 
-  defstruct name: "",
-            major_version: 0,
-            minor_version: 0,
-            type: nil,
-            ownership: nil,
-            aggregation: nil,
-            interface_id: nil,
-            automaton: nil,
-            storage: nil,
-            storage_type: nil
+  typedstruct do
+    field :name, String.t(), default: ""
+    field :major_version, non_neg_integer(), default: 0
+    field :minor_version, non_neg_integer(), default: 0
+    field :type, Type.t()
+    field :ownership, Ownership.t()
+    field :aggregation, Aggregation.t()
+    field :interface_id, :binary
+    field :automaton, {%{}, %{}}
+    field :storage, String.t()
+    field :storage_type, StorageType.t()
+  end
 
   @doc """
   Deserializes an `%InterfaceDescriptor{}` from `db_result`.

--- a/lib/astarte_core/mapping.ex
+++ b/lib/astarte_core/mapping.ex
@@ -20,7 +20,7 @@ defmodule Astarte.Core.Mapping do
   @moduledoc """
   This module handles Interface Mappings using Ecto Changesets
   """
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
   alias Astarte.Core.CQLUtils
   alias Astarte.Core.Mapping
@@ -50,7 +50,7 @@ defmodule Astarte.Core.Mapping do
   ]
 
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :endpoint
     field :value_type, ValueType
     field :reliability, Reliability, default: :unreliable

--- a/lib/astarte_core/mapping/database_retention_policy.ex
+++ b/lib/astarte_core/mapping/database_retention_policy.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.Core.Mapping.DatabaseRetentionPolicy do
   use Ecto.Type
 
+  @type t :: :no_ttl | :use_ttl
+
   @mapping_policy_no_ttl 1
   @mapping_policy_use_ttl 2
   @valid_atoms [

--- a/lib/astarte_core/mapping/reliability.ex
+++ b/lib/astarte_core/mapping/reliability.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.Core.Mapping.Reliability do
   use Ecto.Type
 
+  @type t :: :unreliable | :guaranteed | :unique
+
   @mapping_reliability_unreliable 1
   @mapping_reliability_guaranteed 2
   @mapping_reliability_unique 3

--- a/lib/astarte_core/mapping/retention.ex
+++ b/lib/astarte_core/mapping/retention.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.Core.Mapping.Retention do
   use Ecto.Type
 
+  @type t :: :discard | :volatile | :stored
+
   @mapping_retention_discard 1
   @mapping_retention_volatile 2
   @mapping_retention_stored 3

--- a/lib/astarte_core/mapping/value_type.ex
+++ b/lib/astarte_core/mapping/value_type.ex
@@ -19,6 +19,22 @@
 defmodule Astarte.Core.Mapping.ValueType do
   use Ecto.Type
 
+  @type t ::
+          :double
+          | :integer
+          | :boolean
+          | :longinteger
+          | :string
+          | :binaryblob
+          | :datetime
+          | :doublearray
+          | :integerarray
+          | :booleanarray
+          | :longintegerarray
+          | :stringarray
+          | :binaryblobarray
+          | :datetimearray
+
   @mapping_value_type_double 1
   @mapping_value_type_doublearray 2
   @mapping_value_type_integer 3

--- a/lib/astarte_core/storage_type.ex
+++ b/lib/astarte_core/storage_type.ex
@@ -19,6 +19,13 @@
 defmodule Astarte.Core.StorageType do
   use Ecto.Type
 
+  @type t ::
+          :multi_interface_individual_properties_dbtable
+          | :multi_interface_individual_datastream_dbtable
+          | :one_individual_properties_dbtable
+          | :one_individual_datastream_dbtable
+          | :one_object_datastream_dbtable
+
   @multi_interface_individual_properties_dbtable 1
   @multi_interface_individual_datastream_dbtable 2
   @one_individual_properties_dbtable 3

--- a/lib/astarte_core/triggers/data_trigger.ex
+++ b/lib/astarte_core/triggers/data_trigger.ex
@@ -17,14 +17,31 @@
 #
 
 defmodule Astarte.Core.Triggers.DataTrigger do
-  @enforce_keys [:trigger_targets]
-  defstruct [
-    :interface_id,
-    :path_match_tokens,
-    :value_match_operator,
-    :known_value,
-    :trigger_targets
-  ]
+  use TypedStruct
+  alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
+
+  @type amqp_trigger_target :: AMQPTriggerTarget.t()
+  @type known_value :: term() | nil
+  @type interface_id :: :any_interface | :binary
+  @type path_match_tokens :: :any_endpoint | String.t()
+  @type value_match_operator ::
+          :ANY
+          | :EQUAL_TO
+          | :NOT_EQUAL_TO
+          | :GREATER_THAN
+          | :GREATER_OR_EQUAL_TO
+          | :LESS_THAN
+          | :LESS_OR_EQUAL_TO
+          | :CONTAINS
+          | :NOT_CONTAINS
+
+  typedstruct do
+    field :interface_id, interface_id()
+    field :path_match_tokens, path_match_tokens()
+    field :value_match_operator, value_match_operator()
+    field :known_value, known_value()
+    field :trigger_targets, [amqp_trigger_target()], enforce: true
+  end
 
   def are_congruent?(trigger_a, trigger_b) do
     trigger_a.interface_id == trigger_b.interface_id and

--- a/lib/astarte_core/triggers/policy/error_type.ex
+++ b/lib/astarte_core/triggers/policy/error_type.ex
@@ -20,6 +20,8 @@ defmodule Astarte.Core.Triggers.Policy.ErrorType do
   use Ecto.Type
   alias Astarte.Core.Triggers.Policy
 
+  @type t :: %{}
+
   # a Json
   def type, do: :map
 

--- a/lib/astarte_core/triggers/policy/handler.ex
+++ b/lib/astarte_core/triggers/policy/handler.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Triggers.Policy.Handler do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
   alias Astarte.Core.Triggers.Policy
   alias Astarte.Core.Triggers.Policy.Handler
@@ -53,7 +53,7 @@ defmodule Astarte.Core.Triggers.Policy.Handler do
 
   @derive Jason.Encoder
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :on, Policy.ErrorType
     field :strategy, :string, default: "discard"
   end

--- a/lib/astarte_core/triggers/policy/keyword_error.ex
+++ b/lib/astarte_core/triggers/policy/keyword_error.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Triggers.Policy.ErrorKeyword do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
   @on_constants [
@@ -28,7 +28,7 @@ defmodule Astarte.Core.Triggers.Policy.ErrorKeyword do
 
   @derive Jason.Encoder
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :keyword, :string
   end
 

--- a/lib/astarte_core/triggers/policy/policy.ex
+++ b/lib/astarte_core/triggers/policy/policy.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.Core.Triggers.Policy do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
   alias Astarte.Core.Triggers.Policy
@@ -42,7 +42,7 @@ defmodule Astarte.Core.Triggers.Policy do
 
   @derive Jason.Encoder
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :name
     field :maximum_capacity, :integer
     field :retry_times, :integer

--- a/lib/astarte_core/triggers/policy/range_error.ex
+++ b/lib/astarte_core/triggers/policy/range_error.ex
@@ -17,14 +17,14 @@
 #
 
 defmodule Astarte.Core.Triggers.Policy.ErrorRange do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
   @error_range 400..599
 
   @derive Jason.Encoder
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :error_codes, {:array, :integer}
   end
 

--- a/lib/astarte_core/triggers/simple_trigger_config.ex
+++ b/lib/astarte_core/triggers/simple_trigger_config.ex
@@ -20,7 +20,7 @@ defmodule Astarte.Core.Triggers.SimpleTriggerConfig do
   @moduledoc """
   This module handles the functions for creating a `SimpleTriggerConfig` and converting it to and from a `TaggedSimpleTrigger`.
   """
-  use Ecto.Schema
+  use TypedEctoSchema
 
   import Ecto.Changeset
   alias Astarte.Core.CQLUtils
@@ -38,7 +38,7 @@ defmodule Astarte.Core.Triggers.SimpleTriggerConfig do
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.TriggerTargetContainer
 
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     # Common
     field :type, :string
     field :on, :string

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,8 @@ defmodule Astarte.Core.Mixfile do
       {:cyanide, "~> 2.0"},
       {:ecto, "~> 3.4"},
       {:ecto_morph, "~> 0.1.23"},
+      {:typed_ecto_schema, "~> 0.4"},
+      {:typedstruct, "~> 0.5"},
       {:protobuf, "~> 0.12"},
       {:jason, "~> 1.2"},
       {:elixir_uuid, "~> 1.2"},

--- a/mix.lock
+++ b/mix.lock
@@ -23,5 +23,7 @@
   "protobuf": {:hex, :protobuf, "0.12.0", "58c0dfea5f929b96b5aa54ec02b7130688f09d2de5ddc521d696eec2a015b223", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "75fa6cbf262062073dd51be44dd0ab940500e18386a6c4e87d5819a58964dc45"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
+  "typed_ecto_schema": {:hex, :typed_ecto_schema, "0.4.1", "a373ca6f693f4de84cde474a67467a9cb9051a8a7f3f615f1e23dc74b75237fa", [:mix], [{:ecto, "~> 3.5", [hex: :ecto, repo: "hexpm", optional: false]}], "hexpm", "85c6962f79d35bf543dd5659c6adc340fd2480cacc6f25d2cc2933ea6e8fcb3b"},
+  "typedstruct": {:hex, :typedstruct, "0.5.3", "d68ae424251a41b81a8d0c485328ab48edbd3858f3565bbdac21b43c056fc9b4", [:make, :mix], [], "hexpm", "b53b8186701417c0b2782bf02a2db5524f879b8488f91d1d83b97d84c2943432"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
use typedstruct and typed_ecto_schema for structs and schemas respectively, manually define `t` for `Ecto.Type`s

This is needed for https://github.com/astarte-platform/astarte_data_access/pull/71 to successfully run dialyzer