### PR TITLE
chore: remove `:error_handlers` from required fields

### DIFF
--- a/lib/astarte_core/triggers/policy/policy.ex
+++ b/lib/astarte_core/triggers/policy/policy.ex
@@ -28,7 +28,6 @@ defmodule Astarte.Core.Triggers.Policy do
 
   @required_fields [
     :name,
-    :error_handlers,
     :maximum_capacity
   ]
 


### PR DESCRIPTION
this fixes the following warning:
`attempting to determine the presence of embed_many field :error_handlers with validate_required/3 or field_missing?/2 which has no effect. You can pass the :required option to Ecto.Changeset.cast_embed/3 to achieve this.`

as we already have `required: true` in the `cast_embed`, this should be a non-issue

this is important as it fixes a runtime warning, which pollutes eg tests from https://github.com/astarte-platform/astarte_generators/pull/21