### PR TITLE
feat: json encoder for incoming introspection

### DIFF
--- a/lib/astarte_core/triggers/simple_events/encoder.ex
+++ b/lib/astarte_core/triggers/simple_events/encoder.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 Ispirata Srl
+# Copyright 2018 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,8 +87,34 @@ defmodule Astarte.Core.Triggers.SimpleEvents.Encoder do
     end
   end
 
+  defimpl Jason.Encoder, for: SimpleEvents.InterfaceVersion do
+    alias SimpleEvents.InterfaceVersion
+
+    def encode(interface_version, opts) do
+      %InterfaceVersion{major: major, minor: minor} = interface_version
+
+      %{
+        "major" => major,
+        "minor" => minor
+      }
+      |> Jason.Encoder.encode(opts)
+    end
+  end
+
   defimpl Jason.Encoder, for: SimpleEvents.IncomingIntrospectionEvent do
     alias Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent
+
+    def encode(%IncomingIntrospectionEvent{introspection: nil} = event, opts) do
+      %IncomingIntrospectionEvent{
+        introspection_map: introspection_map
+      } = event
+
+      %{
+        "type" => "incoming_introspection",
+        "introspection" => introspection_map
+      }
+      |> Jason.Encoder.encode(opts)
+    end
 
     def encode(%IncomingIntrospectionEvent{} = event, opts) do
       %IncomingIntrospectionEvent{

--- a/test/astarte_core/triggers/simple_events_encoder_test.exs
+++ b/test/astarte_core/triggers/simple_events_encoder_test.exs
@@ -241,7 +241,7 @@ defmodule Astarte.Core.SimpleEventsEncoderTest do
              }
     end
 
-    test "works for IncomingIntrospectionEvent" do
+    test "works for IncomingIntrospectionEvent with string introspection" do
       alias Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent
 
       introspection = "com.example.Interface:0:2;com.example.AnotherInterface:1:1"
@@ -257,6 +257,34 @@ defmodule Astarte.Core.SimpleEventsEncoderTest do
       assert roundtrip == %{
                "type" => "incoming_introspection",
                "introspection" => introspection
+             }
+    end
+
+    test "works for IncomingIntrospectionEvent with map introspection" do
+      alias Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent
+      alias Astarte.Core.Triggers.SimpleEvents.InterfaceVersion
+
+      introspection = %{
+        "com.example.Interface" => %InterfaceVersion{major: 0, minor: 2},
+        "com.example.AnotherInterface" => %InterfaceVersion{major: 1, minor: 1}
+      }
+
+      introspection_map = %{
+        "com.example.Interface" => %{"major" => 0, "minor" => 2},
+        "com.example.AnotherInterface" => %{"major" => 1, "minor" => 1}
+      }
+
+      event = %IncomingIntrospectionEvent{
+        introspection_map: introspection
+      }
+
+      roundtrip =
+        Jason.encode!(event)
+        |> Jason.decode!()
+
+      assert roundtrip == %{
+               "type" => "incoming_introspection",
+               "introspection" => introspection_map
              }
     end
 


### PR DESCRIPTION
https://github.com/astarte-platform/astarte_core/pull/77 added introspection_map to incoming introspection event, but its jason encoder was never implemented.

this was handled in trigger engine with an ad-hoc "encoder", which did not respect other encoders format, and eg was missing the `type` field in the json 

properly implementing its encoder results in the removal of said custom code