### PR TITLE
feat: add device deletion finished event

### DIFF
--- a/lib/astarte_core/triggers/simple_events/device_deletion_finished_event.pb.ex
+++ b/lib/astarte_core/triggers/simple_events/device_deletion_finished_event.pb.ex
@@ -1,0 +1,5 @@
+defmodule Astarte.Core.Triggers.SimpleEvents.DeviceDeletionFinishedEvent do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto3
+end

--- a/lib/astarte_core/triggers/simple_events/device_deletion_finished_event.proto
+++ b/lib/astarte_core/triggers/simple_events/device_deletion_finished_event.proto
@@ -1,0 +1,22 @@
+//
+// This file is part of Astarte.
+//
+// Copyright 2025 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+message DeviceDeletionFinishedEvent {
+}

--- a/lib/astarte_core/triggers/simple_events/simple_event.pb.ex
+++ b/lib/astarte_core/triggers/simple_events/simple_event.pb.ex
@@ -78,4 +78,9 @@ defmodule Astarte.Core.Triggers.SimpleEvents.SimpleEvent do
     type: Astarte.Core.Triggers.SimpleEvents.DeviceErrorEvent,
     json_name: "deviceErrorEvent",
     oneof: 0
+
+  field :device_deletion_finished_event, 22,
+    type: Astarte.Core.Triggers.SimpleEvents.DeviceDeletionFinishedEvent,
+    json_name: "deviceDeletionFinishedEvent",
+    oneof: 0
 end

--- a/lib/astarte_core/triggers/simple_events/simple_event.proto
+++ b/lib/astarte_core/triggers/simple_events/simple_event.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017 - 2025 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ syntax = "proto3";
 
 import "lib/astarte_core/triggers/simple_events/device_connected_event.proto";
 import "lib/astarte_core/triggers/simple_events/device_disconnected_event.proto";
+import "lib/astarte_core/triggers/simple_events/device_deletion_finished_event.proto";
 import "lib/astarte_core/triggers/simple_events/device_error_event.proto";
 import "lib/astarte_core/triggers/simple_events/incoming_data_event.proto";
 import "lib/astarte_core/triggers/simple_events/value_change_event.proto";
@@ -56,5 +57,6 @@ message SimpleEvent {
         InterfaceRemovedEvent interface_removed_event = 16;
         InterfaceMinorUpdatedEvent interface_minor_updated_event = 17;
         DeviceErrorEvent device_error_event = 19;
+        DeviceDeletionFinishedEvent device_deletion_finished_event = 22;
     }
 }

--- a/lib/astarte_core/triggers/simple_trigger_config.ex
+++ b/lib/astarte_core/triggers/simple_trigger_config.ex
@@ -30,12 +30,10 @@ defmodule Astarte.Core.Triggers.SimpleTriggerConfig do
   alias Astarte.Core.Interface
   alias Astarte.Core.Triggers.SimpleTriggerConfig
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.Utils, as: SimpleTriggersUtils
-  alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DataTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DeviceTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.SimpleTriggerContainer
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.TaggedSimpleTrigger
-  alias Astarte.Core.Triggers.SimpleTriggersProtobuf.TriggerTargetContainer
 
   @primary_key false
   typed_embedded_schema do

--- a/test/astarte_core/interface_test.exs
+++ b/test/astarte_core/interface_test.exs
@@ -380,7 +380,7 @@ defmodule Astarte.Core.InterfaceTest do
     }
 
     assert %Ecto.Changeset{valid?: true} = changeset = Interface.changeset(%Interface{}, params)
-    assert {:ok, interface} = Ecto.Changeset.apply_action(changeset, :insert)
+    assert {:ok, _interface} = Ecto.Changeset.apply_action(changeset, :insert)
   end
 
   test "valid datastream interface" do


### PR DESCRIPTION
```bash
protoc --elixir_out=. --elixir_opt=package_prefix=astarte.core.triggers.simple_events lib/astarte_core/triggers/simple_events/*.proto
```

the event has been assigned code 22 to leave space to device creation and device deletion started

based on #124