### PR TITLE
fix: http triggers for device registration and deletion events

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/astarte_core/triggers/simple_events/encoder.ex
+++ b/lib/astarte_core/triggers/simple_events/encoder.ex
@@ -67,6 +67,39 @@ defmodule Astarte.Core.Triggers.SimpleEvents.Encoder do
     end
   end
 
+  defimpl Jason.Encoder, for: SimpleEvents.DeviceRegisteredEvent do
+    alias Astarte.Core.Triggers.SimpleEvents.DeviceRegisteredEvent
+
+    def encode(%DeviceRegisteredEvent{}, opts) do
+      %{
+        "type" => "device_registered"
+      }
+      |> Jason.Encoder.encode(opts)
+    end
+  end
+
+  defimpl Jason.Encoder, for: SimpleEvents.DeviceDeletionStartedEvent do
+    alias Astarte.Core.Triggers.SimpleEvents.DeviceDeletionStartedEvent
+
+    def encode(%DeviceDeletionStartedEvent{}, opts) do
+      %{
+        "type" => "device_deletion_started"
+      }
+      |> Jason.Encoder.encode(opts)
+    end
+  end
+
+  defimpl Jason.Encoder, for: SimpleEvents.DeviceDeletionFinishedEvent do
+    alias Astarte.Core.Triggers.SimpleEvents.DeviceDeletionFinishedEvent
+
+    def encode(%DeviceDeletionFinishedEvent{}, opts) do
+      %{
+        "type" => "device_deletion_finished"
+      }
+      |> Jason.Encoder.encode(opts)
+    end
+  end
+
   defimpl Jason.Encoder, for: SimpleEvents.IncomingDataEvent do
     alias Astarte.Core.Triggers.SimpleEvents.IncomingDataEvent
 

--- a/test/astarte_core/triggers/simple_events_encoder_test.exs
+++ b/test/astarte_core/triggers/simple_events_encoder_test.exs
@@ -53,6 +53,42 @@ defmodule Astarte.Core.SimpleEventsEncoderTest do
       assert roundtrip == %{"type" => "device_disconnected"}
     end
 
+    test "works for DeviceRegisteredEvent" do
+      alias Astarte.Core.Triggers.SimpleEvents.DeviceRegisteredEvent
+
+      event = %DeviceRegisteredEvent{}
+
+      roundtrip =
+        Jason.encode!(event)
+        |> Jason.decode!()
+
+      assert roundtrip == %{"type" => "device_registered"}
+    end
+
+    test "works for DeviceDeletionStartedEvent" do
+      alias Astarte.Core.Triggers.SimpleEvents.DeviceDeletionStartedEvent
+
+      event = %DeviceDeletionStartedEvent{}
+
+      roundtrip =
+        Jason.encode!(event)
+        |> Jason.decode!()
+
+      assert roundtrip == %{"type" => "device_deletion_started"}
+    end
+
+    test "works for DeviceDeletionFinishedEvent" do
+      alias Astarte.Core.Triggers.SimpleEvents.DeviceDeletionFinishedEvent
+
+      event = %DeviceDeletionFinishedEvent{}
+
+      roundtrip =
+        Jason.encode!(event)
+        |> Jason.decode!()
+
+      assert roundtrip == %{"type" => "device_deletion_finished"}
+    end
+
     test "works for IncomingDataEvent" do
       alias Astarte.Core.Triggers.SimpleEvents.IncomingDataEvent
 

--- a/test/astarte_core/triggers/simple_events_test.exs
+++ b/test/astarte_core/triggers/simple_events_test.exs
@@ -48,6 +48,36 @@ defmodule Astarte.Core.SimpleEventsTest do
       assert DeviceErrorEvent.decode(serialized_event) == event
     end
 
+    test "still works for DeviceRegisteredEvent" do
+      alias Astarte.Core.Triggers.SimpleEvents.DeviceRegisteredEvent
+
+      serialized_event = <<>>
+      event = %DeviceRegisteredEvent{}
+
+      assert DeviceRegisteredEvent.encode(event) == serialized_event
+      assert DeviceRegisteredEvent.decode(serialized_event) == event
+    end
+
+    test "still works for DeviceDeletionStartedEvent" do
+      alias Astarte.Core.Triggers.SimpleEvents.DeviceDeletionStartedEvent
+
+      serialized_event = <<>>
+      event = %DeviceDeletionStartedEvent{}
+
+      assert DeviceDeletionStartedEvent.encode(event) == serialized_event
+      assert DeviceDeletionStartedEvent.decode(serialized_event) == event
+    end
+
+    test "still works for DeviceDeletionFinishedEvent" do
+      alias Astarte.Core.Triggers.SimpleEvents.DeviceDeletionFinishedEvent
+
+      serialized_event = <<>>
+      event = %DeviceDeletionFinishedEvent{}
+
+      assert DeviceDeletionFinishedEvent.encode(event) == serialized_event
+      assert DeviceDeletionFinishedEvent.decode(serialized_event) == event
+    end
+
     test "still works for IncomingDataEvent" do
       alias Astarte.Core.Triggers.SimpleEvents.IncomingDataEvent
 


### PR DESCRIPTION
#125 #126 #127 added new simple events but their encoders were not
defined, which would mean http triggers wouldn't work.

add tests for the newly added triggers

fix a warning